### PR TITLE
feat: save last event time & access token in a state.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,4 @@ dmypy.json
 
 .idea/
 
-events.json
+*.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 This is a simple script that collects events from the Twosense API and stores them in `.json` file.
 The next time it runs, it will only collect new events.
+
+## Requirements
+
+- Python 3.11+
+- A Twosense API client id and client secret
+
 ## Setup
+
 ```bash
     python -m venv venv
     source venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ This is a simple script that collects events from the Twosense API and stores th
 The next time it runs, it will only collect new events.
 ## Setup
 ```bash
+    python -m venv venv
+    source venv/bin/activate
     pip install -r requirements.txt
 ```
 
 ## Run
-[Get an API access token](https://twosense.readme.io/reference/authentication#2-obtain-an-access-token).
+
 ```bash
-    export TWOSENSE_API_TOKEN=<TOKEN>
+    export TWOSENSE_API_CLIENT_ID=<you_client_id>
+    export TWOSENSE_API_CLIENT_SECRET=<you_client_secret>
+    
     python collect_events.py
 ```

--- a/collect_events.py
+++ b/collect_events.py
@@ -1,24 +1,71 @@
 import json
+import logging
 import os
+import time
 
+import jwt
 import requests
 
-# Twosense API access token. Get it here:
-# https://twosense.readme.io/reference/authentication#2-obtain-an-access-token
-API_TOKEN = os.getenv("TWOSENSE_API_TOKEN")
+logging.basicConfig(
+    filename="app.log",
+    filemode="a",
+    format="%(asctime)s [%(levelname)s] - %(message)s",
+    level=logging.INFO,
+)
+
+CLIENT_ID = os.getenv("TWOSENSE_API_CLIENT_ID")
+CLIENT_SECRET = os.getenv("TWOSENSE_API_CLIENT_SECRET")
+
 API_URL = "https://webapi.twosense.ai/events"
 LOG_FILE = "events.json"
+STATE_FILE = "state.json"
 
 
-def fetch_events(since: str | None) -> list[dict]:
+def main():
+    logging.info("Starting event collection")
+
+    state = read_state()
+    last_event_time = state.get("last_event_time")
+    if last_event_time:
+        logging.info(f"Collecting events since {last_event_time}")
+
+    api_token = state.get("api_token")
+    if not is_valid(api_token):
+        api_token = refresh_api_token()
+
+    # Fetch events from the Twosense API
+    events = fetch_events(api_token, last_event_time)
+    logging.info(f"Found {len(events)} new events")
+
+    if not events:
+        logging.info("No new events found")
+        return
+
+    # Save events to a JSON file
+    save_events(events)
+
+    # Update the state file
+    last_event_time = events[-1]["published"]
+    state["last_event_time"] = last_event_time
+    state["api_token"] = api_token
+    with open(STATE_FILE, "w", encoding="utf-8") as file:
+        json.dump(state, file)
+    logging.info(f"State updated with last event time {last_event_time}")
+
+    logging.info("Done")
+    logging.info(50 * "=")
+
+
+def fetch_events(api_token: str, since: str | None) -> list[dict]:
     """
     Fetch events from the Twosense API.
 
+    :param api_token: API access token.
     :param since: Only fetch events that occurred after this time.
     :return: List of events.
     """
     headers = {
-        "Authorization": f"Bearer {API_TOKEN}",
+        "Authorization": f"Bearer {api_token}",
         "Accept": "application/json",
     }
     params = {"since": since} if since else {}
@@ -55,31 +102,58 @@ def save_events(events: list[dict]) -> None:
     with open(LOG_FILE, "w", encoding="utf-8") as file:
         json.dump(events, file, indent=2)
 
+    logging.info(f"Events saved to {LOG_FILE}")
 
-def get_last_event_time(filename: str) -> str | None:
+
+def read_state() -> dict | None:
     """
     Get the time of the last event downloaded from the log file.
 
-    :param filename: Path to the log file.
     :return: Time of the last event, or None if the file does not exist.
     """
-    if not os.path.exists(filename):
-        return None
+    if not os.path.exists(STATE_FILE):
+        return {}
 
-    with open(filename, "r", encoding="utf-8") as file:
-        events = json.load(file)
-        return events[-1].get("published")
+    with open(STATE_FILE, "r", encoding="utf-8") as file:
+        return json.load(file)
 
 
-def main():
-    last_event_time = get_last_event_time(LOG_FILE)
+def is_valid(api_token: str):
+    if not api_token:
+        logging.warning("No API token found")
+        return False
 
-    events = fetch_events(last_event_time)
-    print(f"Found {len(events)} new events")
+    try:
+        now = int(time.time())
+        decoded = jwt.decode(api_token, options={"verify_signature": False})
+        if decoded["exp"] < now:
+            logging.warning("API token has expired")
+            return False
+    except Exception as e:
+        logging.error(f"Error decoding API token: {e}")
+        return False
 
-    if events:
-        save_events(events)
-        print(f"Events saved to {LOG_FILE}")
+    logging.info(f"API token is valid")
+    return True
+
+
+def refresh_api_token():
+    logging.info("Refreshing API token")
+
+    payload = (
+        f'{{"client_id":"{CLIENT_ID}",'
+        f'"client_secret":"{CLIENT_SECRET}",'
+        '"audience":"https://webapi.twosense.ai",'
+        '"grant_type":"client_credentials"}'
+    )
+    headers = {"content-type": "application/json"}
+
+    response = requests.post(
+        "https://auth.twosense.ai/oauth/token", data=payload, headers=headers
+    )
+    response.raise_for_status()
+
+    return response.json()["access_token"]
 
 
 if __name__ == "__main__":

--- a/collect_events.py
+++ b/collect_events.py
@@ -105,7 +105,7 @@ def save_events(events: list[dict]) -> None:
     logging.info(f"Events saved to {LOG_FILE}")
 
 
-def read_state() -> dict | None:
+def read_state() -> dict:
     """
     Get the time of the last event downloaded from the log file.
 
@@ -118,7 +118,7 @@ def read_state() -> dict | None:
         return json.load(file)
 
 
-def is_valid(api_token: str):
+def is_valid(api_token: str) -> bool:
     if not api_token:
         logging.warning("No API token found")
         return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
+black==24.4.1
 certifi==2024.2.2
 charset-normalizer==3.3.2
+click==8.1.7
+colorama==0.4.6
 idna==3.7
+mypy-extensions==1.0.0
+packaging==24.0
+pathspec==0.12.1
+platformdirs==4.2.1
+PyJWT==2.8.0
 requests==2.31.0
 urllib3==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
-black==24.4.1
-certifi==2024.2.2
-charset-normalizer==3.3.2
-click==8.1.7
-colorama==0.4.6
-idna==3.7
-mypy-extensions==1.0.0
-packaging==24.0
-pathspec==0.12.1
-platformdirs==4.2.1
 PyJWT==2.8.0
 requests==2.31.0
-urllib3==2.2.1


### PR DESCRIPTION
* Manage the API token. Refresh it when it expires.
* Save the last downloaded event's `published` timestamp instead of reading it from `events.json`. This is helpful in case the user wants to store the events elsewhere.
* Log to `app.log` file.